### PR TITLE
Add sales_person (AE) to diff fingerprint to detect AE reassignments

### DIFF
--- a/.claude/tasks/lessons.md
+++ b/.claude/tasks/lessons.md
@@ -492,4 +492,13 @@ Always `str(contract).strip()` and coerce `'0'` to `''` on both sides.
 - Excel fingerprints must be filtered to open months only before comparing
   to DB fingerprints (which only query open months)
 
-**Last Updated**: 2026-03-24
+### Rule 50: Rebuild Docker container after code changes
+Code changes on the host are NOT picked up by the daily update — it runs
+inside Docker. After modifying Python files, always:
+```bash
+docker compose build spotops && docker compose up -d spotops
+```
+before triggering or waiting for a daily update. Failure to do this led to
+a false "bug" where an AE fingerprint fix appeared not to work.
+
+**Last Updated**: 2026-04-03

--- a/src/services/import_diff.py
+++ b/src/services/import_diff.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Tuple
 
 # Type aliases
 GroupKey = Tuple[str, str, str]  # (bill_code, contract, broadcast_month)
-Fingerprint = Tuple[int, int]   # (sum_cents, row_count)
+Fingerprint = Tuple[int, int, str]  # (sum_cents, row_count, ae_key)
 
 
 def build_db_fingerprints(
@@ -33,16 +33,19 @@ def build_db_fingerprints(
             CASE WHEN contract IS NULL OR contract = '' OR contract = '0' THEN '' ELSE contract END AS contract,
             broadcast_month,
             CAST(SUM(CAST(ROUND(COALESCE(spot_value, 0) * 100, 0) AS INTEGER)) AS INTEGER) AS sum_cents,
-            COUNT(*) AS row_count
+            COUNT(*) AS row_count,
+            GROUP_CONCAT(DISTINCT COALESCE(sales_person, '')) AS ae_raw
         FROM spots
         WHERE broadcast_month IN ({placeholders})
         GROUP BY bill_code, CASE WHEN contract IS NULL OR contract = '' OR contract = '0' THEN '' ELSE contract END, broadcast_month
     """
     cursor = conn.execute(sql, months)
-    return {
-        (row[0], row[1], row[2]): (row[3], row[4])
-        for row in cursor.fetchall()
-    }
+    result = {}
+    for row in cursor.fetchall():
+        ae_raw = row[5] or ""
+        ae_key = ",".join(sorted(ae_raw.split(",")))
+        result[(row[0], row[1], row[2])] = (row[3], row[4], ae_key)
+    return result
 
 
 # Column indices matching EXCEL_COLUMN_POSITIONS
@@ -50,6 +53,7 @@ _COL_BILL_CODE = 0
 _COL_SPOT_VALUE = 17
 _COL_BROADCAST_MONTH = 18
 _COL_REVENUE_TYPE = 23
+_COL_SALES_PERSON = 22
 _COL_CONTRACT = 27
 
 
@@ -70,6 +74,7 @@ def build_excel_fingerprints(
     grouped_rows: Dict[GroupKey, List[Tuple]] = defaultdict(list)
     sums: Dict[GroupKey, int] = defaultdict(int)
     counts: Dict[GroupKey, int] = defaultdict(int)
+    ae_sets: Dict[GroupKey, set] = defaultdict(set)
     months_found: set = set()
 
     for raw_row in rows:
@@ -97,13 +102,20 @@ def build_excel_fingerprints(
         raw_value = row[_COL_SPOT_VALUE] if len(row) > _COL_SPOT_VALUE else None
         cents = round(float(raw_value) * 100) if raw_value is not None else 0
 
+        sales_person = row[_COL_SALES_PERSON] if len(row) > _COL_SALES_PERSON else None
+        sales_person = str(sales_person).strip() if sales_person else ""
+
         key: GroupKey = (bill_code, contract, month)
         grouped_rows[key].append(raw_row)
         sums[key] += cents
         counts[key] += 1
+        ae_sets[key].add(sales_person)
         months_found.add(month)
 
-    fingerprints = {key: (sums[key], counts[key]) for key in sums}
+    fingerprints = {
+        key: (sums[key], counts[key], ",".join(sorted(ae_sets[key])))
+        for key in sums
+    }
     return dict(fingerprints), dict(grouped_rows), months_found
 
 
@@ -143,9 +155,11 @@ def compare_fingerprints(
     CENTS_TOLERANCE = 10
 
     for key in common:
-        excel_cents, excel_count = excel_fps[key]
-        db_cents, db_count = db_fps[key]
-        if excel_count == db_count and abs(excel_cents - db_cents) <= CENTS_TOLERANCE:
+        excel_cents, excel_count, excel_ae = excel_fps[key]
+        db_cents, db_count, db_ae = db_fps[key]
+        if (excel_count == db_count
+                and abs(excel_cents - db_cents) <= CENTS_TOLERANCE
+                and excel_ae == db_ae):
             unchanged.add(key)
         else:
             changed.add(key)

--- a/tests/services/test_import_diff.py
+++ b/tests/services/test_import_diff.py
@@ -24,7 +24,8 @@ def _create_test_db():
             broadcast_month TEXT,
             spot_value DECIMAL(12,2),
             air_date DATE,
-            import_batch_id TEXT
+            import_batch_id TEXT,
+            sales_person TEXT
         );
         CREATE TABLE month_closures (
             broadcast_month TEXT PRIMARY KEY
@@ -37,17 +38,18 @@ def _create_test_db():
 
 def _make_row(bill_code="BC1", air_date="2026-03-01",
               spot_value=100.00, broadcast_month="Mar-26",
-              contract="C100"):
+              contract="C100", sales_person=None):
     """Build a 30-element tuple matching EXCEL_COLUMN_POSITIONS.
 
     Index 0=bill_code, 1=air_date, 17=spot_value,
-    18=broadcast_month, 27=contract.
+    18=broadcast_month, 22=sales_person, 27=contract.
     """
     row = [None] * 30
     row[0] = bill_code
     row[1] = air_date
     row[17] = spot_value
     row[18] = broadcast_month
+    row[22] = sales_person
     row[27] = contract
     return tuple(row)
 
@@ -64,19 +66,19 @@ class TestBuildDbFingerprints:
         conn, path = _create_test_db()
         try:
             conn.executemany(
-                "INSERT INTO spots (bill_code, contract, broadcast_month, spot_value) VALUES (?,?,?,?)",
+                "INSERT INTO spots (bill_code, contract, broadcast_month, spot_value, sales_person) VALUES (?,?,?,?,?)",
                 [
-                    ("Acme:Widget", "C100", "Mar-26", 150.00),
-                    ("Acme:Widget", "C100", "Mar-26", 50.00),
-                    ("Acme:Widget", "C200", "Mar-26", 75.00),
+                    ("Acme:Widget", "C100", "Mar-26", 150.00, "Alice"),
+                    ("Acme:Widget", "C100", "Mar-26", 50.00, "Alice"),
+                    ("Acme:Widget", "C200", "Mar-26", 75.00, "Bob"),
                 ],
             )
             conn.commit()
 
             fps = build_db_fingerprints(["Mar-26"], conn)
 
-            assert fps[("Acme:Widget", "C100", "Mar-26")] == (20000, 2)
-            assert fps[("Acme:Widget", "C200", "Mar-26")] == (7500, 1)
+            assert fps[("Acme:Widget", "C100", "Mar-26")] == (20000, 2, "Alice")
+            assert fps[("Acme:Widget", "C200", "Mar-26")] == (7500, 1, "Bob")
         finally:
             conn.close()
             os.unlink(path)
@@ -94,7 +96,7 @@ class TestBuildDbFingerprints:
 
             fps = build_db_fingerprints(["Mar-26"], conn)
             assert ("BC1", "", "Mar-26") in fps
-            assert fps[("BC1", "", "Mar-26")] == (1000, 1)
+            assert fps[("BC1", "", "Mar-26")] == (1000, 1, "")
         finally:
             conn.close()
             os.unlink(path)
@@ -111,7 +113,7 @@ class TestBuildDbFingerprints:
             conn.commit()
 
             fps = build_db_fingerprints(["Mar-26"], conn)
-            assert fps[("BC1", "C1", "Mar-26")] == (0, 1)
+            assert fps[("BC1", "C1", "Mar-26")] == (0, 1, "")
         finally:
             conn.close()
             os.unlink(path)
@@ -144,15 +146,15 @@ class TestBuildExcelFingerprints:
         from src.services.import_diff import build_excel_fingerprints
 
         rows = [
-            _make_row("Acme:Widget", "2026-03-01", 150.00, "Mar-26", "C100"),
-            _make_row("Acme:Widget", "2026-03-02", 50.00, "Mar-26", "C100"),
-            _make_row("Acme:Widget", "2026-03-03", 75.00, "Mar-26", "C200"),
+            _make_row("Acme:Widget", "2026-03-01", 150.00, "Mar-26", "C100", "Alice"),
+            _make_row("Acme:Widget", "2026-03-02", 50.00, "Mar-26", "C100", "Alice"),
+            _make_row("Acme:Widget", "2026-03-03", 75.00, "Mar-26", "C200", "Bob"),
         ]
 
         fps, grouped, months = build_excel_fingerprints(rows)
 
-        assert fps[("Acme:Widget", "C100", "Mar-26")] == (20000, 2)
-        assert fps[("Acme:Widget", "C200", "Mar-26")] == (7500, 1)
+        assert fps[("Acme:Widget", "C100", "Mar-26")] == (20000, 2, "Alice")
+        assert fps[("Acme:Widget", "C200", "Mar-26")] == (7500, 1, "Bob")
         assert len(grouped[("Acme:Widget", "C100", "Mar-26")]) == 2
         assert len(grouped[("Acme:Widget", "C200", "Mar-26")]) == 1
         assert "Mar-26" in months
@@ -162,7 +164,7 @@ class TestBuildExcelFingerprints:
 
         rows = [_make_row("BC1", "2026-03-01", None, "Mar-26", "C1")]
         fps, _, _ = build_excel_fingerprints(rows)
-        assert fps[("BC1", "C1", "Mar-26")] == (0, 1)
+        assert fps[("BC1", "C1", "Mar-26")] == (0, 1, "")
 
     def test_null_contract_coalesced(self):
         from src.services.import_diff import build_excel_fingerprints
@@ -182,7 +184,7 @@ class TestBuildExcelFingerprints:
         fps, grouped, months = build_excel_fingerprints(rows)
         # Only the third row should be included
         assert len(fps) == 1
-        assert fps[("BC1", "C1", "Mar-26")] == (5000, 1)
+        assert fps[("BC1", "C1", "Mar-26")] == (5000, 1, "")
 
     def test_handles_rows_with_sheet_tag(self):
         """Rows with >30 columns (sheet-name tag) should be handled."""
@@ -193,7 +195,7 @@ class TestBuildExcelFingerprints:
         assert len(tagged_row) == 31
 
         fps, grouped, _ = build_excel_fingerprints([tagged_row])
-        assert fps[("BC1", "C1", "Mar-26")] == (10000, 1)
+        assert fps[("BC1", "C1", "Mar-26")] == (10000, 1, "")
         # grouped_rows should preserve the full raw row (with tag)
         assert len(grouped[("BC1", "C1", "Mar-26")][0]) == 31
 
@@ -207,8 +209,8 @@ class TestCompareFingerprints:
     def test_unchanged_groups(self):
         from src.services.import_diff import compare_fingerprints
 
-        excel = {("BC1", "C1", "Mar-26"): (10000, 2)}
-        db = {("BC1", "C1", "Mar-26"): (10000, 2)}
+        excel = {("BC1", "C1", "Mar-26"): (10000, 2, "Alice")}
+        db = {("BC1", "C1", "Mar-26"): (10000, 2, "Alice")}
         result = compare_fingerprints(excel, db)
 
         assert ("BC1", "C1", "Mar-26") in result.unchanged
@@ -220,8 +222,8 @@ class TestCompareFingerprints:
         from src.services.import_diff import compare_fingerprints
 
         key = ("BC1", "C1", "Mar-26")
-        excel = {key: (10000, 2)}
-        db = {key: (5000, 2)}  # $50 difference — clearly changed
+        excel = {key: (10000, 2, "Alice")}
+        db = {key: (5000, 2, "Alice")}  # $50 difference — clearly changed
         result = compare_fingerprints(excel, db)
 
         assert key in result.changed
@@ -231,8 +233,8 @@ class TestCompareFingerprints:
         from src.services.import_diff import compare_fingerprints
 
         key = ("BC1", "C1", "Mar-26")
-        excel = {key: (10000, 3)}
-        db = {key: (10000, 2)}  # different row_count
+        excel = {key: (10000, 3, "Alice")}
+        db = {key: (10000, 2, "Alice")}  # different row_count
         result = compare_fingerprints(excel, db)
 
         assert key in result.changed
@@ -241,7 +243,7 @@ class TestCompareFingerprints:
         from src.services.import_diff import compare_fingerprints
 
         key = ("BC1", "C1", "Mar-26")
-        excel = {key: (10000, 2)}
+        excel = {key: (10000, 2, "Alice")}
         db = {}
         result = compare_fingerprints(excel, db)
 
@@ -253,7 +255,7 @@ class TestCompareFingerprints:
 
         key = ("BC1", "C1", "Mar-26")
         excel = {}
-        db = {key: (10000, 2)}
+        db = {key: (10000, 2, "Alice")}
         result = compare_fingerprints(excel, db)
 
         assert key in result.removed
@@ -269,11 +271,11 @@ class TestCompareFingerprints:
         for i in range(10):
             key = (f"BC{i}", "C1", "Mar-26")
             if i < 9:
-                excel[key] = (100, 1)
-                db[key] = (999, 1)  # different
+                excel[key] = (100, 1, "Alice")
+                db[key] = (999, 1, "Alice")  # different
             else:
-                excel[key] = (100, 1)
-                db[key] = (100, 1)  # same
+                excel[key] = (100, 1, "Alice")
+                db[key] = (100, 1, "Alice")  # same
 
         result = compare_fingerprints(excel, db)
         assert result.should_fallback is True
@@ -290,13 +292,106 @@ class TestCompareFingerprints:
         for i in range(10):
             key = (f"BC{i}", "C1", "Mar-26")
             if i < 1:
-                excel[key] = (100, 1)
-                db[key] = (999, 1)  # different
+                excel[key] = (100, 1, "Alice")
+                db[key] = (999, 1, "Alice")  # different
             else:
-                excel[key] = (100, 1)
-                db[key] = (100, 1)  # same
+                excel[key] = (100, 1, "Alice")
+                db[key] = (100, 1, "Alice")  # same
 
         result = compare_fingerprints(excel, db)
         assert result.should_fallback is False
         assert len(result.changed) == 1
         assert len(result.unchanged) == 9
+
+    def test_ae_change_detected(self):
+        """Same dollars and count but different AE → group marked changed."""
+        from src.services.import_diff import compare_fingerprints
+
+        key = ("BC1", "C1", "Mar-26")
+        excel = {key: (10000, 2, "Bob")}
+        db = {key: (10000, 2, "Alice")}
+        result = compare_fingerprints(excel, db)
+
+        assert key in result.changed
+        assert key not in result.unchanged
+
+    def test_ae_unchanged(self):
+        """Same dollars, count, and AE → group unchanged."""
+        from src.services.import_diff import compare_fingerprints
+
+        key = ("BC1", "C1", "Mar-26")
+        excel = {key: (10000, 2, "Alice")}
+        db = {key: (10000, 2, "Alice")}
+        result = compare_fingerprints(excel, db)
+
+        assert key in result.unchanged
+        assert key not in result.changed
+
+
+# ===========================================================================
+# Task 4 — AE fingerprint integration (Excel + DB round-trip)
+# ===========================================================================
+
+class TestAeFingerprinting:
+
+    def test_excel_captures_sales_person(self):
+        """Excel fingerprints include sales_person in ae_key."""
+        from src.services.import_diff import build_excel_fingerprints
+
+        rows = [
+            _make_row("BC1", "2026-03-01", 100.00, "Mar-26", "C1", "Alice"),
+            _make_row("BC1", "2026-03-02", 200.00, "Mar-26", "C1", "Alice"),
+        ]
+        fps, _, _ = build_excel_fingerprints(rows)
+        assert fps[("BC1", "C1", "Mar-26")] == (30000, 2, "Alice")
+
+    def test_excel_multiple_aes_sorted(self):
+        """Multiple AEs in one group produce a sorted, comma-joined key."""
+        from src.services.import_diff import build_excel_fingerprints
+
+        rows = [
+            _make_row("BC1", "2026-03-01", 100.00, "Mar-26", "C1", "Zara"),
+            _make_row("BC1", "2026-03-02", 100.00, "Mar-26", "C1", "Alice"),
+        ]
+        fps, _, _ = build_excel_fingerprints(rows)
+        assert fps[("BC1", "C1", "Mar-26")] == (20000, 2, "Alice,Zara")
+
+    def test_db_captures_sales_person(self):
+        """DB fingerprints include sales_person in ae_key."""
+        from src.services.import_diff import build_db_fingerprints
+
+        conn, path = _create_test_db()
+        try:
+            conn.executemany(
+                "INSERT INTO spots (bill_code, contract, broadcast_month, spot_value, sales_person) VALUES (?,?,?,?,?)",
+                [
+                    ("BC1", "C1", "Mar-26", 100.00, "Alice"),
+                    ("BC1", "C1", "Mar-26", 200.00, "Alice"),
+                ],
+            )
+            conn.commit()
+            fps = build_db_fingerprints(["Mar-26"], conn)
+            assert fps[("BC1", "C1", "Mar-26")] == (30000, 2, "Alice")
+        finally:
+            conn.close()
+            os.unlink(path)
+
+    def test_db_multiple_aes_sorted(self):
+        """Multiple AEs in DB group produce a sorted, comma-joined key."""
+        from src.services.import_diff import build_db_fingerprints
+
+        conn, path = _create_test_db()
+        try:
+            conn.executemany(
+                "INSERT INTO spots (bill_code, contract, broadcast_month, spot_value, sales_person) VALUES (?,?,?,?,?)",
+                [
+                    ("BC1", "C1", "Mar-26", 100.00, "Zara"),
+                    ("BC1", "C1", "Mar-26", 100.00, "Alice"),
+                ],
+            )
+            conn.commit()
+            fps = build_db_fingerprints(["Mar-26"], conn)
+            assert fps[("BC1", "C1", "Mar-26")] == (20000, 2, "Alice,Zara")
+        finally:
+            conn.close()
+            os.unlink(path)


### PR DESCRIPTION
Previously the diff-based import only compared sum_cents and row_count per contract group. If an AE changed but dollars stayed the same, the change was invisible and the DB kept the stale AE.